### PR TITLE
prevent script from falling over for devices with no "switch" field

### DIFF
--- a/utils/smartthingtest.py
+++ b/utils/smartthingtest.py
@@ -23,7 +23,7 @@ async def switch():
             print("found device: ", device.device_id, device.name, device.label)
             if device.device_id == device_id or device_id == "":
                 await device.status.refresh()
-                print(" device status is :" + device.status.values.get("switch"))
+                print(" device status is :" + device.status.values.get("switch",""))
 
 
 asyncio.run(switch())


### PR DESCRIPTION
Tapo cameras etc do not have "switch" entry; prevent script from falling over when these are present and ALL devices requested.